### PR TITLE
Remove dead guide link

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
     - "presidio"
     - "anonymization"
     - "P II"
-  guide: https://docs.quarkiverse.io/presidio/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  # guide: https://docs.quarkiverse.io/presidio/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
   categories:
     - "security"
     - "AI"


### PR DESCRIPTION
At the moment, the link shown on https://quarkus.io/extensions/io.quarkiverse.presidio/quarkus-presidio/ is a 404.