### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/presidio/deployment/PresidioProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/presidio/deployment/PresidioProcessor.java
@@ -12,7 +12,7 @@ import io.quarkus.deployment.IsNormal;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.smallrye.health.deployment.spi.HealthBuildItem;
 
 class PresidioProcessor {
@@ -24,7 +24,7 @@ class PresidioProcessor {
         return new FeatureBuildItem(FEATURE);
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createAnalyzerContainer(PresidioDevServiceConfig config) {
 
         if (!config.enabledAnalyzer()) {
@@ -48,7 +48,7 @@ class PresidioProcessor {
                 .toBuildItem();
     }
 
-    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+    @BuildStep(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
     public DevServicesResultBuildItem createAnonymizerContainer(PresidioDevServiceConfig config) {
 
         if (!config.enabledAnonymizer()) {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </scm>
 
     <properties>
-        <quarkus.version>3.17.5</quarkus.version>
+        <quarkus.version>3.20.0</quarkus.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in 3.26 so we should avoid it.

> [!WARNING]
> Note that this requires to set the minimum version to 3.20, so you might have to have a maintenance branch for 3.15 if you want to push new versions supporting 3.15 after this is in.